### PR TITLE
Fix CRAN incoming check warnings for nwsrfsr 1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,12 @@ setup_*.sh
 *_report.md
 *_checklist.md
 
+# R build arifacts
+00*.log
+
+# rendered md should not usually be included, but might in specefic cases using -f 
+*.html
+
 # python package docs
 /nwsrfs_py/docs/build/
 /nwsrfs_py/docs/_build/

--- a/model_source/Makevars
+++ b/model_source/Makevars
@@ -12,14 +12,14 @@ uh2p_get_scale.o: uh_optim.o
 
 # These files use obsolete features and so fail when using the default -std=f95
 fka7.o: fka7.f
-	$(FC) -c -fPIC -Wall -O3 fka7.f
+	$(FC) -c -fPIC -O2 fka7.f
 flag7.o: flag7.f
-	$(FC) -c -fPIC -Wall -O3 flag7.f
+	$(FC) -c -fPIC -O2 flag7.f
 pin7.o: pin7.f
-	$(FC) -c -fPIC -Wall -O3 pin7.f
+	$(FC) -c -fPIC -O2 pin7.f
 ex57.o: ex57.f
-	$(FC) -c -fPIC -Wall -O3 ex57.f
+	$(FC) -c -fPIC -O2 ex57.f
 SNDEPTH.o: SNDEPTH.f
-	$(FC) -c -fPIC -Wall -O3 SNDEPTH.f
+	$(FC) -c -fPIC -O2 SNDEPTH.f
 exsnow19.o: exsnow19.f
-	$(FC) -c -fPIC -Wall -O3 exsnow19.f
+	$(FC) -c -fPIC -O2 exsnow19.f

--- a/model_source/Makevars.win
+++ b/model_source/Makevars.win
@@ -1,0 +1,25 @@
+PKG_FFLAGS =
+PKG_FCFLAGS =
+
+all: $(SHLIB)
+
+# need to tell R the order to compile dependent modules
+sac_snow_only_tci.o sac_snow_states.o: utilities.o
+FA.o: utilities.o
+utilities.o: types.o stats.o sorting.o
+stats.o: types.o sorting.o
+uh2p_get_scale.o: uh_optim.o
+
+# These files use obsolete features and so fail when using the default -std=f95
+fka7.o: fka7.f
+	$(FC) -c -O2 fka7.f
+flag7.o: flag7.f
+	$(FC) -c -O2 flag7.f
+pin7.o: pin7.f
+	$(FC) -c -O2 pin7.f
+ex57.o: ex57.f
+	$(FC) -c -O2 ex57.f
+SNDEPTH.o: SNDEPTH.f
+	$(FC) -c -O2 SNDEPTH.f
+exsnow19.o: exsnow19.f
+	$(FC) -c -O2 exsnow19.f

--- a/model_source/blockdata_fatlgk.f
+++ b/model_source/blockdata_fatlgk.f
@@ -1,0 +1,8 @@
+      BLOCK DATA FATLGK_INIT
+C
+C     Standard Fortran initialization of COMMON block /FATLGK/
+C     (moved from DATA statement in initCommonBlocksPin.f)
+C
+      COMMON /FATLGK/ IATL,C1,C2
+      DATA IATL, C1, C2 / 1, 12.0, 100.0 /
+      END

--- a/model_source/ex42.f
+++ b/model_source/ex42.f
@@ -29,7 +29,7 @@ CGW      include 'flogm'
       COMMON/FCARY/IFILLC,NCSTOR,ICDAY(20),ICHOUR(20)      
 C
 C    ================================= RCS keyword statements ==========
-      CHARACTER*68     RCSKW1,RCSKW2
+      CHARACTER(LEN=68)     RCSKW1,RCSKW2
       DATA             RCSKW1,RCSKW2 /                                 '
      .$Source: /fs/hseb/ob72/rfc/ofs/src/fcst_ex/RCS/ex42.f,v $
      . $',                                                             '

--- a/model_source/initCommonBlocksPin.f
+++ b/model_source/initCommonBlocksPin.f
@@ -1,11 +1,9 @@
 
       SUBROUTINE initCommonBlocksPin(FILENAME)
 
-      CHARACTER*1024 FILENAME
+      CHARACTER(LEN=1024) FILENAME
       COMMON/IONUM/IN,IPR,IPU
       COMMON /FATLGK/ IATL,C1,C2
-      
-      DATA  IATL, C1, C2 / 1, 12.0, 100.0 /
       
 
       IN = 1

--- a/nwsrfs_py/meson.build
+++ b/nwsrfs_py/meson.build
@@ -29,7 +29,7 @@ fortran_sources = files(
   'src/fop7.f', 'src/fserc7.f', 'src/fslag7.f', 'src/pin7.f', 'src/pina7.f',
   'src/umemov.f', 'src/umemst.f', 'src/PACK19.f', 'src/exsnow19.f', 'src/aesc19.f',
   'src/rout19.f', 'src/zero19.f', 'src/duamel.f', 'src/sac1.f', 'src/ex_sac1.f',
-  'src/melt19.f', 'src/ex57.f', 'src/ex42.f'
+  'src/melt19.f', 'src/ex57.f', 'src/ex42.f', 'src/blockdata_fatlgk.f'
 )
 
 generated_f2py_sources = [

--- a/nwsrfs_r/.Rbuildignore
+++ b/nwsrfs_r/.Rbuildignore
@@ -15,3 +15,4 @@
 ^LICENSE\.md$
 ^LICENSE\.note$
 ^README\.html$
+^win-builder-notes\.md$

--- a/nwsrfs_r/README.md
+++ b/nwsrfs_r/README.md
@@ -24,7 +24,8 @@ provides R, gfortran, and test dependencies):
 pixi run install-r
 ```
 
-See the [top-level README](../README.md#development-environment-pixi)
+See the [top-level
+README](https://github.com/NOAA-NWRFC/nwsrfs-hydro-models#development-environment-pixi)
 for pixi setup details.
 
 Or from R:

--- a/nwsrfs_r/README.qmd
+++ b/nwsrfs_r/README.qmd
@@ -22,7 +22,7 @@ Using [pixi](https://pixi.prefix.dev/) (recommended for development — provides
 pixi run install-r
 ```
 
-See the [top-level README](../README.md#development-environment-pixi) for pixi setup details.
+See the [top-level README](https://github.com/NOAA-NWRFC/nwsrfs-hydro-models#development-environment-pixi) for pixi setup details.
 
 Or from R:
 

--- a/nwsrfs_r/cran-comments.md
+++ b/nwsrfs_r/cran-comments.md
@@ -16,3 +16,15 @@
   that is not set up in the example code. The high-level entry points
   (`load_example()`, `fa_nwrfc()`, `fa_adj_nwrfc()`) use `\donttest{}` and
   run successfully.
+* Package includes both Makevars and Makevars.win. The Windows variant omits -fPIC (not needed on Windows). Win-builder R-devel, R-release, and R-oldrelease all build and pass tests successfully with 0 errors
+  and 0 warnings.
+
+## Win-builder results
+
+Tested on win-builder with 0 errors, 0 warnings, 2 NOTEs (new submission + license)
+across all platforms:
+
+  - R-release: https://win-builder.r-project.org/T6Egg9Kbaqu8/
+  - R-oldrelease: https://win-builder.r-project.org/SNPBLmbsk2xE/
+  - R-devel: https://win-builder.r-project.org/J2KmSRwBV8Ut/
+  - R-devel (with Makevars.win): https://win-builder.r-project.org/1Z5VozPj1YRl/

--- a/nwsrfs_r/cran-comments.md
+++ b/nwsrfs_r/cran-comments.md
@@ -28,3 +28,4 @@ across all platforms:
   - R-oldrelease: https://win-builder.r-project.org/SNPBLmbsk2xE/
   - R-devel: https://win-builder.r-project.org/J2KmSRwBV8Ut/
   - R-devel (with Makevars.win): https://win-builder.r-project.org/1Z5VozPj1YRl/
+  - https://win-builder.r-project.org/qM24yJf454P9/

--- a/nwsrfs_r/inst/WORDLIST
+++ b/nwsrfs_r/inst/WORDLIST
@@ -1,0 +1,5 @@
+CHANLOSS
+CONSUSE
+NWS
+SMA
+hydrograph


### PR DESCRIPTION
Address 5 issues flagged by CRAN r-devel-windows and r-devel-linux incoming checks:

1. Fortran CHARACTER syntax: Replace GNU extension CHARACTER*N with standard CHARACTER(LEN=N) in ex42.f and initCommonBlocksPin.f (flagged by flang on r-devel-windows).

2. COMMON block initialization: Move DATA statement for /FATLGK/ COMMON block variables from initCommonBlocksPin.f into a proper BLOCK DATA program unit (blockdata_fatlgk.f). The Fortran standard requires COMMON block variables to be initialized in BLOCK DATA units, not in regular subroutines.

3. Makevars portability: Remove -Wall flag from custom Fortran compile rules (not supported by flang) and reduce -O3 to -O2 for safer cross-platform optimization.

4. README relative link: Replace ../README.md relative path with absolute GitHub URL in nwsrfs_r/README.qmd and README.md, since CRAN-hosted package pages cannot resolve relative links outside the package directory.

5. Spelling dictionary: Add inst/WORDLIST with domain-specific terms (CHANLOSS, CONSUSE, NWS, SMA, hydrograph) to suppress false positive spelling NOTEs.

Also adds blockdata_fatlgk.f to the Python meson.build source list since both packages share model_source/ via symlink.

Validated: R CMD check --as-cran (0 errors, 0 warnings, 3 NOTEs), R testthat (42 pass), Python pytest (15 pass).