### PR TITLE
fix(ci): repair docs and macOS wheel builds on main

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -15,6 +15,13 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
 
+    env:
+      # Oldest macOS the published wheels support. Read by the toolchain guard in the macOS
+      # Fortran step and passed through to cibuildwheel, so the two cannot drift apart.
+      # The /opt/gfortran runtime targets macOS 11, so this floor can be lowered without
+      # changing the toolchain. Ignored on Linux and Windows.
+      WHEEL_MACOS_TARGET: "15.0"
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -37,15 +44,37 @@ jobs:
       - name: Install macOS Fortran compiler
         if: runner.os == 'macOS'
         run: |
-          # Homebrew gcc/gfortran version can change over time; delocate will bundle those runtime dylibs.
-          # If this starts failing, re-check Homebrew package names/paths and deployment target compatibility.
-          brew install gcc
-          if ! command -v gfortran >/dev/null 2>&1; then
-            GF="$(ls "$(brew --prefix)/bin"/gfortran-* | head -n1)"
-            ln -sf "$GF" "$(brew --prefix)/bin/gfortran"
-          fi
-          echo "$(brew --prefix)/bin" >> "$GITHUB_PATH"
-          gfortran --version
+          # CRAN's universal gfortran, the same toolchain dev/README.md prescribes for the R
+          # package. Its libgfortran/libquadmath/libgcc_s target macOS 11, so delocate can
+          # bundle them into a wheel built for an older macOS than the runner.
+          #
+          # Homebrew's gcc does not work here. Its bottles are built for the runner's own
+          # macOS, so when macos-latest moved from macOS 15 to macOS 26 the runtime picked up
+          # a 26.0 minimum and delocate refused to repair the 15.0-tagged wheel.
+          set -euo pipefail
+          curl -fLO https://mac.r-project.org/tools/gfortran-14.2-universal.pkg
+          sudo installer -pkg gfortran-14.2-universal.pkg -target /
+          rm -f gfortran-14.2-universal.pkg
+          echo "/opt/gfortran/bin" >> "$GITHUB_PATH"
+          /opt/gfortran/bin/gfortran --version
+
+          # Assert the property this toolchain was chosen for. If a future gfortran build
+          # raises its runtime target above the wheel floor, fail here with a clear message
+          # rather than deep inside cibuildwheel's delocate step.
+          target_major="${WHEEL_MACOS_TARGET%%.*}"
+          for lib in libgfortran.5 libquadmath.0 libgcc_s.1.1; do
+            path="$(find /opt/gfortran/lib/gcc -name "$lib.dylib" -path '*aarch64*' | head -n1)"
+            if [ -z "$path" ]; then
+              echo "::error::$lib.dylib not found under /opt/gfortran; toolchain layout changed"
+              exit 1
+            fi
+            minos="$(otool -l "$path" | awk '/LC_BUILD_VERSION/{f=1} f && /minos/{print $2; exit}')"
+            echo "$lib minos=$minos (wheel floor ${WHEEL_MACOS_TARGET})"
+            if [ "${minos%%.*}" -gt "$target_major" ]; then
+              echo "::error::$lib targets macOS $minos, above the ${WHEEL_MACOS_TARGET} wheel floor"
+              exit 1
+            fi
+          done
 
       - name: Install Windows Fortran compiler
         if: runner.os == 'Windows'
@@ -99,8 +128,11 @@ jobs:
           # re-check bundled DLLs and this repair command.
           CIBW_BEFORE_BUILD_WINDOWS: "python -m pip install --upgrade pip delvewheel"
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair --add-path C:/msys64/mingw64/bin -w {dest_dir} {wheel}"
-          # Homebrew gcc runtime currently requires macOS 15+; lowering this target without changing toolchain will fail.
-          CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET=15.0"
+          # delocate reads MACOSX_DEPLOYMENT_TARGET to decide whether the bundled dylibs are
+          # old enough for the wheel tag, so it has to be set for the repair step too, not just
+          # the compile. Without it delocate silently renames the wheel up to the runner's macOS.
+          # FC is pinned so meson cannot pick up some other gfortran that lands on PATH.
+          CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET=${{ env.WHEEL_MACOS_TARGET }} FC=/opt/gfortran/bin/gfortran"
         with:
           # GitHub can occasionally return 429 while cibuildwheel fetches virtualenv.pyz.
           # Retry the whole build to avoid failing on transient infrastructure errors.

--- a/.github/workflows/pages-docs.yml
+++ b/.github/workflows/pages-docs.yml
@@ -17,6 +17,12 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    env:
+      # nwsrfs_r/.Rprofile sources renv/activate.R, which would hijack the library and break
+      # setup-r-dependencies (pak not found in the renv lib). Same reason as test-r.yml.
+      RENV_CONFIG_AUTOLOADER_ENABLED: "FALSE"
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -27,9 +33,29 @@ jobs:
       - name: Build Sphinx docs (Python package)
         run: pixi run sphinx-build -b html nwsrfs_py/docs/source _site/python
 
+      # R is not managed by pixi (see dev/README.md), so the docs job installs it the same way
+      # the other R workflows do. pkgdown runs outside pixi on purpose: R's Makeconf on Linux
+      # resolves FC=gfortran through PATH, and inside `pixi run` that would compile the package
+      # with conda-forge's gfortran against the system R.
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          # local::. installs nwsrfsr itself, which build_site(install = FALSE) needs loadable.
+          # pkgdown is a maintainer-only dependency, so it is not declared in DESCRIPTION.
+          extra-packages: any::pkgdown, local::.
+          working-directory: nwsrfs_r
+
       - name: Build pkgdown site (R package)
+        working-directory: nwsrfs_r
+        run: Rscript -e 'pkgdown::build_site(install = FALSE, preview = FALSE)'
+
+      - name: Stage pkgdown site
         run: |
-          pixi run build-docs-r
           mkdir -p _site/r
           cp -R nwsrfs_r/docs/. _site/r/
 


### PR DESCRIPTION
Two unrelated failures on `main` after the merge of #31.

## Docs build (`Publish Documentation`)

`aae04a0` dropped pixi-managed R. The other R workflows moved to `r-lib/actions`, but `pages-docs.yml` still set up only pixi and called `pixi run build-docs-r`, so the pkgdown step died with `Rscript: command not found` (exit 127).

Installs R and pandoc the way `test-r.yml` does and runs pkgdown directly instead of through the pixi task. Staying outside pixi is deliberate: R's `Makeconf` on Linux resolves `FC=gfortran` through `PATH`, so `pixi run` would compile the package with conda-forge's gfortran against the system R. That mismatch is invisible on macOS, where CRAN's `Makeconf` hardcodes `/opt/gfortran`.

## macOS wheels (`Build Wheels`)

Unrelated to the R changes. `macos-latest` moved from `macos-15-arm64` (Homebrew GCC 13.4.0) to `macos-26-arm64` (Homebrew GCC 16.1.0). Homebrew bottles gcc for the runner's own macOS, so the runtime dylibs picked up a 26.0 minimum target and delocate refused to repair the `macosx_15_0`-tagged wheel:

```
DelocationError: Library dependencies do not satisfy target MacOS version 15.0:
  libgfortran.5.dylib has a minimum target of 26.0
  libquadmath.0.dylib has a minimum target of 26.0
```

Switches to the CRAN universal gfortran already prescribed for the R package in `dev/README.md`. Its runtime targets macOS 11, so the bundled dylibs stay under the wheel floor regardless of which macOS the runner ships. A guard asserts that property right after install, so a future toolchain bump fails with a clear message instead of inside cibuildwheel's repair step.

The floor is hoisted into `WHEEL_MACOS_TARGET` so the guard and cibuildwheel cannot drift apart, and `FC` is pinned so meson cannot pick up a different gfortran.

## Verification

Both workflows dispatched against this branch:

- [Build Wheels](https://github.com/NOAA-NWRFC/nwsrfs-hydro-models/actions/runs/30622023171) — all three OS jobs green. Guard logged `minos=11.0` for all three runtime libs against the 15.0 floor, and cp310/311/312 all produced `macosx_15_0_arm64` wheels, so the tag did not drift upward.
- [Publish Documentation](https://github.com/NOAA-NWRFC/nwsrfs-hydro-models/actions/runs/30622028339) — `build` job green at every step. The `deploy` job was rejected by the `github-pages` environment protection rule, which only permits `main`; that resolves once merged.

The wheel fix was also reproduced and verified locally on a macOS 26 host with the same Homebrew GCC 16.1.0: the failure reproduces byte for byte, and with `/opt/gfortran` the wheel repairs cleanly and passes all 15 tests once installed.

## Follow-up, not included here

The old comment noted the 15.0 floor existed *because* of the Homebrew runtime. That constraint is now gone, since `/opt/gfortran` targets macOS 11. Lowering `WHEEL_MACOS_TARGET` would widen compatibility for published wheels, but it changes what ships to PyPI, so it is left as a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)