### PR TITLE
fix(ci): source the static gfortran runtime from a macOS 11 toolchain

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -15,6 +15,12 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
 
+    env:
+      # Oldest macOS the published wheels support. Passed to cibuildwheel and read by the
+      # post-build check, so the tag and the assertion cannot drift apart.
+      # Ignored on Linux and Windows.
+      WHEEL_MACOS_TARGET: "11.0"
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -33,10 +39,22 @@ jobs:
       # macOS compiler setup
       - name: Install macOS Fortran compiler
         if: runner.os == 'macOS'
-        uses: fortran-lang/setup-fortran@v1
-        with:
-          compiler: gcc
-          version: '13'
+        run: |
+          # CRAN's universal gfortran, the same toolchain dev/README.md prescribes for the R
+          # package. Its static libgfortran/libquadmath/libgcc are built for macOS 11, so the
+          # objects linked into the wheel match the deployment target it is tagged with.
+          #
+          # Homebrew's gcc is bottled for the runner's own macOS. Linking its archives at 11.0
+          # works, but emits ~200 "object file was built for newer 'macOS' version" warnings
+          # and leaves the macOS 11 claim resting on object code compiled against a much newer
+          # SDK. Using it also meant setting CC=gcc, which built the C sources with GCC instead
+          # of Apple clang.
+          set -euo pipefail
+          curl -fLO https://mac.r-project.org/tools/gfortran-14.2-universal.pkg
+          sudo installer -pkg gfortran-14.2-universal.pkg -target /
+          rm -f gfortran-14.2-universal.pkg
+          echo "/opt/gfortran/bin" >> "$GITHUB_PATH"
+          /opt/gfortran/bin/gfortran --version
 
       # Windows compiler setup
       - name: Install Windows Fortran compiler
@@ -94,8 +112,10 @@ jobs:
           # re-check bundled DLLs and this repair command.
           CIBW_BEFORE_BUILD_WINDOWS: "python -m pip install --upgrade pip delvewheel"
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair --add-path C:/msys64/mingw64/bin -w {dest_dir} {wheel}"
-          # macOS: Set base deployment target for Apple Silicon compatibility (macOS 11.0+)
-          CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET=11.0"
+          # macOS: Set base deployment target for Apple Silicon compatibility (macOS 11.0+).
+          # FC is pinned so meson uses the CRAN toolchain rather than any gfortran that happens
+          # to be on PATH. CC is left alone so the C sources keep building with Apple clang.
+          CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET=${{ env.WHEEL_MACOS_TARGET }} FC=/opt/gfortran/bin/gfortran"
         with:
           # GitHub can occasionally return 429 while cibuildwheel fetches virtualenv.pyz.
           # Retry the whole build to avoid failing on transient infrastructure errors.
@@ -108,6 +128,42 @@ jobs:
         run: |
           python -m pip install --upgrade twine
           python -m twine check wheelhouse/*.whl
+
+      - name: Verify macOS wheels are self-contained and match their tag
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          # The macosx_11_0 tag is a compatibility claim CI cannot exercise directly, because
+          # the runner is many releases newer. Assert the two properties it rests on: the
+          # extension links no gfortran runtime dylib, and it is built for the target we claim.
+          set -euo pipefail
+          target_tag="macosx_${WHEEL_MACOS_TARGET//./_}"
+          work="$(mktemp -d)"
+          for whl in wheelhouse/*.whl; do
+            name="$(basename "$whl")"
+            echo "== $name"
+            case "$name" in
+              *"$target_tag"*) ;;
+              *) echo "::error::$name is not tagged $target_tag"; exit 1 ;;
+            esac
+            rm -rf "$work/x" && mkdir -p "$work/x"
+            unzip -q "$whl" -d "$work/x"
+            so="$(find "$work/x" -name '*.so' | head -n1)"
+            if [ -z "$so" ]; then
+              echo "::error::no extension module found in $name"; exit 1
+            fi
+            if otool -L "$so" | tail -n +2 | grep -qE 'libgfortran|libquadmath|libgcc'; then
+              echo "::error::$name links the gfortran runtime dynamically; static link did not apply"
+              otool -L "$so" | tail -n +2
+              exit 1
+            fi
+            minos="$(otool -l "$so" | awk '/LC_BUILD_VERSION/{f=1} f && /minos/{print $2; exit}')"
+            echo "   minos=$minos, no gfortran runtime dylib"
+            if [ "$minos" != "$WHEEL_MACOS_TARGET" ]; then
+              echo "::error::$name is built for macOS $minos but tagged ${WHEEL_MACOS_TARGET}"
+              exit 1
+            fi
+          done
 
       - name: Smoke test install from built wheel artifact
         run: |

--- a/nwsrfs_py/meson.build
+++ b/nwsrfs_py/meson.build
@@ -80,24 +80,39 @@ py_dep = py.dependency()
 ext_link_args = []
 
 if host_machine.system() == 'darwin'
-  ext_link_args += [
-    '-Wl,-undefined,dynamic_lookup',
-    '-static-libgfortran',
-  ]
-  
-  # Query gfortran for static libquadmath
-  qm_res = run_command(
-    fc.cmd_array(), ['-print-file-name=libquadmath.a'],
-    check : false
-  )
-  qm_path = qm_res.stdout().strip()
+  ext_link_args += ['-Wl,-undefined,dynamic_lookup']
 
-  # gfortran returns an absolute path if found, or just 'libquadmath.a' if not found.
-  if qm_path.startswith('/')
-    ext_link_args += [qm_path]
-  else
-    # Fallback for environments (like Conda/Pixi) where static quadmath isn't present
-    ext_link_args += fc.get_supported_link_arguments('-lquadmath')
+  # Link the gfortran runtime statically so the wheel carries no external dylib
+  # dependency and delocate has nothing to bundle. That sidesteps delocate's check
+  # that every bundled dylib is old enough for MACOSX_DEPLOYMENT_TARGET, which is
+  # what broke when the runner image moved to macOS 26.
+  #
+  # The archives are linked by absolute path rather than via -static-libgfortran.
+  # That flag is understood only by the gcc driver, so it silently does nothing when
+  # the extension is linked by Apple clang. Absolute paths work with either linker
+  # and keep clang as the C compiler.
+  #
+  # gfortran prints an absolute path when the archive exists and echoes the bare
+  # name when it does not, so a leading slash is the "found" test. Conda and pixi
+  # ship no static archives; those builds fall through to dynamic linking.
+  foreach lib : ['libgfortran.a', 'libquadmath.a']
+    res = run_command(fc.cmd_array(), ['-print-file-name=' + lib], check : false)
+    path = res.stdout().strip()
+    if path.startswith('/')
+      ext_link_args += [path]
+    elif lib == 'libquadmath.a'
+      ext_link_args += fc.get_supported_link_arguments('-lquadmath')
+    endif
+  endforeach
+
+  # libgcc must come last: it resolves the soft-float helpers (__divtf3 and friends)
+  # pulled in by the two archives above. Without it the link still succeeds, because
+  # -undefined,dynamic_lookup defers the symbols, and the failure only appears as an
+  # ImportError at load time.
+  gcc_res = run_command(fc.cmd_array(), ['-print-file-name=libgcc.a'], check : false)
+  gcc_path = gcc_res.stdout().strip()
+  if gcc_path.startswith('/')
+    ext_link_args += [gcc_path]
   endif
 endif
 


### PR DESCRIPTION
Follow-up to #35. Keeps that PR's static-linking approach, which is the right call, and changes only where the static archives come from.

## The residual issue

#35 statically links libgfortran and libquadmath so the wheel carries no external dylib and can be tagged `macosx_11_0`. The archives come from a Homebrew bottle built for the runner's own macOS, so linking them at 11.0 emits 219 warnings:

```
ld: warning: object file (.../gcc@13/13.4.0/lib/gcc/13/libquadmath.a(isinfq.o))
    was built for newer 'macOS' version (16.0) than being linked (11.0)
```

The published wheel then claims macOS 11 support while containing object code compiled against a much newer SDK, and CI only ever runs it on macOS 26.

To gauge how real that is, I dumped every imported symbol from the wheel currently on `main`. All 190 are long-standing POSIX, libc and CPython entries, nothing from macOS 12 or later. So those wheels very likely do work on macOS 11. The claim is untested rather than wrong.

## The change

Take the archives from CRAN's universal gfortran, the toolchain `dev/README.md` already prescribes for the R package. Its `libgfortran.a`, `libquadmath.a` and `libgcc.a` are all built at `minos 11.0`, so the objects match the target the wheel is tagged with.

Two details worth calling out:

**Linked by absolute path, not `-static-libgfortran`.** That flag is understood only by the gcc driver. Relying on it required `setup-fortran`'s `update-environment`, which sets `CC=gcc` as well as `FC`, so the C sources were being built by Homebrew GCC 13 instead of Apple clang. Absolute paths work with either linker, so this restores clang for the C while keeping the static link.

**`libgcc.a` has to come last.** Without it the link still succeeds, because `-undefined,dynamic_lookup` defers the soft-float helpers, and the failure appears only at load time as `ImportError: symbol not found in flat namespace '___divtf3'`.

Also adds a post-build check asserting each macOS wheel links no gfortran runtime dylib and is built for the target it is tagged with, since that is the claim the runner cannot exercise directly.

## Verification

[CI run on this branch](https://github.com/NOAA-NWRFC/nwsrfs-hydro-models/actions/runs/30656493578), all three OS jobs green:

- `ld: warning` count in the build step: **0**, against 219 on `main`
- `Fortran compiler: /opt/gfortran/bin/gfortran (GCC 14.2.0)`, `C compiler: Apple clang 21.0.0`
- All three wheels: `minos=11.0, no gfortran runtime dylib`, tagged `macosx_11_0_arm64`

Locally on macOS 26 arm64: delocate bundles nothing, `libSystem` is the only dependency, and all 15 tests pass against the installed wheel. Building through pixi still resolves dynamically and imports fine, so local development is unaffected.

## Not included

Two other things I noticed while comparing, left alone here:

- `pages-docs.yml` is pinned to `ubuntu-22.04` with a revert-later note.
- Under `pixi run build-docs-r` the R package is compiled by conda-forge gfortran 14.4.0 against the system R, not the toolchain `test-r.yml` and CRAN use. Harmless for docs, since pkgdown only needs the package loadable, but it is a latent inconsistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)