### PR TITLE
fix(ci): unpin the docs runner and build the R package with system R

### DIFF
--- a/.github/workflows/pages-docs.yml
+++ b/.github/workflows/pages-docs.yml
@@ -16,38 +16,61 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04 #Try to revert to ubuntu-latest in the future
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # 1. Install System R on the runner
+      # --- R toolchain (not managed by pixi, see dev/README.md) ---
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
       - name: Set up R
         uses: r-lib/actions/setup-r@v2
-
-      # 2. Restore R packages from renv.lock (including pkgdown)
-      - name: Set up renv
-        uses: r-lib/actions/setup-renv@v2
         with:
-          working-directory: nwsrfs_r
+          use-public-rspm: true
 
-      # 1b. Install system C/C++ libraries required by R packages (gert, curl, xml2, etc.)
-      - name: Install system dependencies for R packages
+      - name: Cache renv library
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/R/renv
+          key: renv-${{ runner.os }}-${{ hashFiles('nwsrfs_r/renv.lock') }}
+          restore-keys: renv-${{ runner.os }}-
+
+      - name: Restore pkgdown from renv.lock
+        working-directory: nwsrfs_r
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libgit2-dev libcurl4-openssl-dev libssl-dev libxml2-dev libharfbuzz-dev libfribidi-dev
+          # Restore only pkgdown and its recursive dependencies (55 of the 95 packages in
+          # the lockfile) rather than the whole thing. A full restore also installs the
+          # maintainer tools, and one of them, gert, links libgit2, whose soname differs
+          # between Ubuntu releases. That coupling is what previously pinned this job to
+          # ubuntu-22.04. The docs build uses none of those packages.
+          Rscript -e 'renv::restore(packages = "pkgdown", prompt = FALSE)'
 
-      # 3. Set up Pixi for Python/docs dependencies
+      - name: Install R package into the renv library
+        working-directory: nwsrfs_r
+        run: |
+          # Compile with the system R toolchain. Doing this through `pixi run install-r`
+          # instead builds the package with conda-forge's gfortran against the system R,
+          # because R's Makeconf on Linux resolves FC=gfortran through PATH and pixi puts
+          # its own compilers first. That does not happen on macOS, where CRAN's Makeconf
+          # hardcodes /opt/gfortran, so it only ever showed up here.
+          Rscript -e 'Sys.setenv(R_LIBS = paste(.libPaths(), collapse = .Platform[["path.sep"]])); status <- system2("R", c("CMD", "INSTALL", ".")); if (!identical(status, 0L)) quit(status = status)'
+
+      # --- Python/docs toolchain ---
+
       - name: Set up pixi
         uses: prefix-dev/setup-pixi@v0.10.0
 
-      # 4. Use Pixi to build Python and R Docs
       - name: Build Sphinx docs (Python package)
         run: pixi run sphinx-build -b html nwsrfs_py/docs/source _site/python
 
       - name: Build pkgdown site (R package)
+        working-directory: nwsrfs_r
+        run: Rscript -e 'pkgdown::build_site(install = FALSE, preview = FALSE)'
+
+      - name: Stage pkgdown site
         run: |
-          pixi run build-docs-r
           mkdir -p _site/r
           cp -R nwsrfs_r/docs/. _site/r/
 
@@ -63,7 +86,7 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           path: _site
-  
+
   #Note that deploy only runs on main
   deploy:
     if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
Follow-up to #35, cleaning up the two loose ends in the docs job. R side only, no changes to the Python package.

## The ubuntu-22.04 pin

The pin traced to a single package rather than an Ubuntu-wide incompatibility. `setup-renv` restores all 95 packages in `renv.lock`, including the maintainer tools (`devtools`, `usethis`, `roxygen2`) that the docs build never touches. `gert` comes in through that set, links libgit2, and failed on ubuntu-24.04 with:

```
error testing if 'gert' can be loaded
libgit2.so.1.7: cannot open shared object file: No such file or directory
```

Two things worth noting from the logs: renv was already resolving the correct channel (`packagemanager.posit.co/cran/__linux__/noble/latest`), so this was not a stale-binary problem. And the apt step meant to supply that library was ordered after the restore, so it could not have helped.

Rather than chase the system library, restore only pkgdown and its recursive dependencies, 55 of the 95 packages. That drops `gert` along with the rest of the maintainer tooling, removes the distro coupling, and lets the job run on `ubuntu-latest` again. The apt list is no longer needed and goes away.

Package versions still come from `renv.lock`, so the published docs are built with the same pkgdown as local development.

## The R package was built by conda's gfortran

`pixi run build-docs-r` compiled the package with conda-forge gfortran rather than the toolchain the system R expects. R's `Makeconf` on Linux resolves `FC=gfortran` through `PATH`, and pixi puts its own compilers first. CRAN's `Makeconf` on macOS hardcodes `/opt/gfortran`, which is why this only ever showed up on the runner.

It was harmless in practice, since pkgdown only needs the package loadable inside the pixi environment, but it meant the docs job built the package with a different toolchain than `test-r.yml` and CRAN use. Installing and building the site with system R directly avoids it. pixi still builds the Sphinx docs and `README.html`.

## Verification

[Run on this branch](https://github.com/NOAA-NWRFC/nwsrfs-hydro-models/actions/runs/30717181028), build job green:

| | before | after |
|---|---|---|
| runner | `ubuntu-22.04` (pinned) | `ubuntu-24.04` via `ubuntu-latest` |
| packages restored | 95 | 55, in 16s |
| apt list | 6 packages | none |
| Fortran compiler | conda-forge gcc 14.4.0 | Ubuntu gfortran 13.3.0 |
| pkgdown | 2.2.1 | 2.2.1 |
| reference pages built | 44 | 44 |

Site output is identical. `deploy` skipped cleanly on the branch thanks to the `if: github.ref == 'refs/heads/main'` guard from #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)